### PR TITLE
Fixed dirbuster appearing twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Table of Contents
    * https://code.google.com/p/ratproxy/ Ratproxy
    * http://www.websecurify.com Websecurify
    * http://sourceforge.net/projects/grendel/ Grendel-scan
-   * https://www.owasp.org/index.php/Category:OWASP_DirBuster_Project DirBuster
    * https://tools.kali.org/web-applications/gobuster Directory/file and DNS busting tool written in Go
    * http://www.edge-security.com/wfuzz.php Wfuzz
    * http://wapiti.sourceforge.net wapiti


### PR DESCRIPTION
## DirBuster appears twice in the document.

The first instance is in line 63 and the second one is in 89 with the same link.

## Change:
- removed line 89