### PR TITLE
Add new resource to Labs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Table of Contents
    * https://github.com/oliverwiegers/pentest_lab - Local pentest lab leveraging docker compose.
    * https://ginandjuice.shop/catalog
    * https://github.com/dolevf/Damn-Vulnerable-GraphQL-Application
+   * https://labex.io/skilltrees/cybersecurity - LabEx is an online platform for enhancing your cyber security skills through hands-on labs.
 
 ## SSL
 


### PR DESCRIPTION
Add LabEx cybersecurity labs to Labs section.

I work at LabEx, a unique learning platform that has delivered thousands of hands-on labs over the past 7 years. Our Cybersecurity Skill Tree currently offers 34 foundational skills and 80 hands-on labs, making it perfect for beginners to learn cybersecurity step by step. 

This repo is a great resource. Please let me know if any changes are needed.