### PR TITLE
Add OopsSec Store to Labs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Table of Contents
    * https://github.com/dolevf/Damn-Vulnerable-GraphQL-Application
    * https://labex.io/skilltrees/cybersecurity - LabEx is an online platform for enhancing your cyber security skills through hands-on labs.
    * https://pythoncyber.go.ro - CyberPython helps you to make your own research in order to solve challenges, exploit CVEs and make good scripts.
+   * https://github.com/kOaDT/oss-oopssec-store - OSS – OopsSec Store: An intentionally vulnerable e-commerce application built with Next.js and React for web security training and CTF practice.
 
 ## SSL
 


### PR DESCRIPTION
This PR adds OopsSec Store to the Labs section.

**Transparency note:** I am the owner and maintainer of this project. I believe it can be a valuable resource for the penetration testing and web security community and would like to share it with others who might find it useful.

OopsSec Store is an intentionally vulnerable e-commerce application built with Next.js and React. The project features:

- Capture The Flag (CTF) challenges with hidden flags to discover
- Comprehensive vulnerability documentation for learning and training
- Production-like single-page application (SPA) environment with REST APIs
- Quick setup using `npx create-oss-store`

Repository: https://github.com/kOaDT/oss-oopssec-store