### PR TITLE
Add PageGuard - free website health scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Table of Contents
    * [https://columbus.elmasy.com/](https://columbus.elmasy.com/) - Columbus Project is an advanced subdomain discovery service with fast, powerful and easy to use API.
    * [BadUSB Script To Exfiltrate Passwords](https://github.com/MarkCyber/BadUSB/blob/main/HackStuff/CredentialHarvester.txt) - Extracts all saved passwords from Chrome, Firefox, and Edge to be saved onto secondary USB for further analysis.
    * https://github.com/flibustier/jwt-online-cracker - Brute-force HS256, HS384 or HS512 JWT Token from your browser (fully client-side).
+   * [PageGuard](https://pageguard.qiudeqiu.workers.dev) - Website security audit and health check tool. Identifies configuration issues, missing security headers, and best practice violations. Free REST API.
 
 ## Cheat Sheets
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Table of Contents
    * [https://columbus.elmasy.com/](https://columbus.elmasy.com/) - Columbus Project is an advanced subdomain discovery service with fast, powerful and easy to use API.
    * [BadUSB Script To Exfiltrate Passwords](https://github.com/MarkCyber/BadUSB/blob/main/HackStuff/CredentialHarvester.txt) - Extracts all saved passwords from Chrome, Firefox, and Edge to be saved onto secondary USB for further analysis.
    * https://github.com/flibustier/jwt-online-cracker - Brute-force HS256, HS384 or HS512 JWT Token from your browser (fully client-side).
-   * [PageGuard](https://pageguard.qiudeqiu.workers.dev) - Website security audit and health check tool. Identifies configuration issues, missing security headers, and best practice violations. Free REST API.
+   * [PageGuard](https://pageguard.org) - Website security audit and health check tool. Identifies configuration issues, missing security headers, and best practice violations. Free REST API.
 
 ## Cheat Sheets
 


### PR DESCRIPTION
## What is PageGuard?

[PageGuard](https://pageguard.qiudeqiu.workers.dev) is a free website security audit and health check tool that identifies missing security headers, HTTPS configuration issues, and best practice violations. It also exposes a free REST API for automated scanning.

## Why it belongs here

The **Tools** section already includes web security scanners like Nikto, OWASP ZAP, and Arachni. PageGuard complements these by focusing on configuration-level security issues — specifically missing or misconfigured security headers, HTTPS enforcement, and common web security best practice violations. It is accessible without authentication, making it useful for quick reconnaissance during penetration testing or red team engagements.

## Details

- Free with no signup required
- REST API for automated/scripted scanning
- Covers: security headers (CSP, HSTS, X-Frame-Options, etc.), HTTPS, SEO, performance, accessibility