### PR TITLE
Add keyFinder - passive API key & secret scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Table of Contents
    * [BadUSB Script To Exfiltrate Passwords](https://github.com/MarkCyber/BadUSB/blob/main/HackStuff/CredentialHarvester.txt) - Extracts all saved passwords from Chrome, Firefox, and Edge to be saved onto secondary USB for further analysis.
    * https://github.com/flibustier/jwt-online-cracker - Brute-force HS256, HS384 or HS512 JWT Token from your browser (fully client-side).
    * https://github.com/lukechilds/reverse-shell - Easy to remember reverse shell that should work on most Unix-like systems.
+   * https://github.com/momenbasel/keyFinder - Chrome extension that passively scans web pages for leaked API keys, tokens, and secrets using 80+ detection patterns and Shannon entropy across 10 attack surfaces.
 
 ## Cheat Sheets
 


### PR DESCRIPTION
## Summary

Adds [keyFinder](https://github.com/momenbasel/keyFinder) to the Tools section.

keyFinder is a Chrome extension (556+ stars, MIT license, Manifest V3) that passively scans every web page for leaked API keys, tokens, and secrets. It uses 80+ detection patterns and Shannon entropy analysis across 10 attack surfaces:

- Inline scripts & external JS
- Meta tags & HTML comments
- Hidden form fields & data attributes
- Web Storage (localStorage/sessionStorage)
- Cookies
- Network responses (XHR/Fetch)

Zero dependencies, runs entirely client-side in the browser. Useful for reconnaissance, bug bounty, and security audits.