### PR TITLE
Add Scorifya to SSL section

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Table of Contents
    * https://letsencrypt.org/ - Let’s Encrypt is a new Certificate Authority: It’s free, automated, and open.
    * https://filippo.io/Heartbleed/ - A checker (site and tool) for CVE-2014-0160 (Heartbleed).
    * https://testssl.sh/ - A command line tool which checks a website's TLS/SSL ciphers, protocols and cryptographic flaws.
+   * [Scorifya](https://www.scorifya.com) - 0–100 security score for any website covering TLS, security headers (CSP, HSTS, X-Frame-Options), cookies, DNS, and email signals (SPF, DKIM, DMARC) with ranked fix steps.
 
 ## Security Ruby on Rails
 


### PR DESCRIPTION
[Scorifya](https://www.scorifya.com) is a freemium website security scanner that gives any site a 0–100 score across TLS/HTTPS configuration, security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options), cookie hygiene, DNS signals (DNSSEC, CAA, SPF, DKIM, DMARC, MTA-STS), and exposure indicators.

It fits the SSL section alongside SSL Labs and testssl.sh — it covers TLS as one of its five scored categories, plus the broader header/DNS security surface that those tools don't cover.

- Live product at https://www.scorifya.com
- No signup required for a scan
- Freemium model