### PR TITLE
Add SaaSFort (free external NIS2/security posture scanner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Table of Contents
    * https://github.com/lukechilds/reverse-shell - Easy to remember reverse shell that should work on most Unix-like systems.
    * https://github.com/momenbasel/keyFinder - Chrome extension that passively scans web pages for leaked API keys, tokens, and secrets using 80+ detection patterns and Shannon entropy across 10 attack surfaces.
    * https://github.com/DenisPodgurskii/pentestkit - Browser-based vulnerability scanner for bug bounty and pentesting workflows, combining DAST, SAST, IAST, and SCA capabilities to detect runtime, source-level, interactive, and dependency-related security issues.
+- [SaaSFort](https://saasfort.com/scan) - Free 60-second external NIS2 / security posture scan, A-F grade, no signup required.
 
 ## Cheat Sheets
 


### PR DESCRIPTION
Adding SaaSFort under the scanning tools.

It runs about 60 external checks against a public domain (TLS, DNS, security headers, common OWASP-style web exposures) and maps results to NIS2 Article 21 and ISO 27001 Annex A, returning an A-F grade with the per-check breakdown. The scan is free and needs no signup.

I use it for a quick external-posture read before audits and security questionnaires, so it seemed like a useful addition here. Link: https://saasfort.com/scan