### PR TITLE
Add Next.js security headers starter to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Table of Contents
 ## Tools
    * https://github.com/bad-antics/nullsec-linux - NullSec Linux - Security distribution with pre-configured web application testing tools
    * https://github.com/bad-antics/nullsec-webfuzz - NullSec WebFuzz - Web application fuzzing framework
+   * https://github.com/poszothebuilder/nextjs-security-headers-starter - Dependency-free Next.js security headers starter with CSP, HSTS, and a production verifier for CI.
 
    * https://www.deepinfo.com/ - Deepinfo Attack Surface Platform discovers all your digital assets, monitors them 24/7, detects any issues, and notifies you quickly so you can take immediate action.
      * https://github.com/bountyyfi/lonkero - Enterprise-grade web vulnerability scanner with 60+ attack modules, built in Rust for penetration testing and security assessments.


### PR DESCRIPTION
Adds Poszo’s MIT-licensed Next.js security headers starter to the Tools section.

It includes CSP and HSTS examples plus a dependency-free production verifier suitable for CI. The repository and linked documentation are public and currently reachable.