### PR TITLE
Add CC.LA — free online domain & network toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Table of Contents
    * https://spyse.com/ - OSINT search engine that provides fresh data about the entire web, storing all data in its own DB, interconnect finding data and has some cool features.
    * http://www.metasploit.com/ - World's most used penetration testing software
    * https://findsubdomains.com - Online subdomains scanner service with lots of additional data. works using OSINT.
+   * https://cc.la - Free online toolkit for WHOIS, RDAP, DNS, IP WHOIS, SSL certificate lookup, name server history, network diagnostics (ping/traceroute/MTR), and domain monitoring. No sign-up required.
    * https://github.com/BlessedRebuS/Krawl - Cloud-native Web deception server and anti-crawler.
    * https://github.com/bjeborn/basic-auth-pot HTTP Basic Authentication honeyPot.
    * http://www.arachni-scanner.com/ - Web Application Security Scanner Framework


### PR DESCRIPTION
Add [CC.LA](https://cc.la) to Tools section — a free online toolkit for WHOIS, RDAP, DNS, IP WHOIS, SSL certificate lookup, name server history, network diagnostics (ping/traceroute/MTR), and domain monitoring. No sign-up required.